### PR TITLE
bump `rocket` to `0.5.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "Rocket Guards to support validation using validator"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0-rc.4", default-features = false, features = [
+rocket = { version = "0.5.0", default-features = false, features = [
     "json",
 ] }
 validator = { version = "0.16.1", features = ["derive"] }


### PR DESCRIPTION
Just bumps to latest, as far as I know - there were no breaking changes between this and rc4, all tests pass. 

Happy to make any necessary changes - let me know!