### PR TITLE
Rocket 0.5 support and 422 error for validation-failed jsons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "Rocket Guards to support validation using validator"
 path = "src/lib.rs"
 
 [dependencies]
-rocket = { version = "0.5.0-rc.4", default-features = false, features = [
+rocket = { version = "0.5.0", default-features = false, features = [
     "json",
 ] }
 validator = { version = "0.16.1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,12 +133,12 @@ pub struct Error<'a> {
 ///  /* right here ---->*/.register("/", catchers![rocket_validation::validation_catcher])
 ///  }
 ///  ```
-#[catch(400)]
+#[catch(422)]
 pub fn validation_catcher<'a>(req: &'a Request) -> Json<Error<'a>> {
     Json(Error {
-        code: 400,
-        message: "Bad Request. The request could not be understood by the server due to malformed \
-                  syntax.",
+        code: 422,
+        message: "Unprocessable Entity. The request was well-formed \
+                  but was unable to be followed due to semantic errors.",
         errors: req.local_cache(|| CachedValidationErrors(None)).0.as_ref(),
     })
 }
@@ -190,7 +190,7 @@ impl<'r, D: Validate + rocket::serde::Deserialize<'r>> FromData<'r> for Validate
                 Ok(_) => Outcome::Success(Validated(data)),
                 Err(err) => {
                     req.local_cache(|| CachedValidationErrors(Some(err.to_owned())));
-                    Outcome::Error((Status::BadRequest, Ok(err)))
+                    Outcome::Error((Status::UnprocessableEntity, Ok(err)))
                 }
             },
         }
@@ -213,7 +213,7 @@ impl<'r, D: Validate + FromRequest<'r>> FromRequest<'r> for Validated<D> {
                 Ok(_) => Outcome::Success(Validated(data)),
                 Err(err) => {
                     req.local_cache(|| CachedValidationErrors(Some(err.to_owned())));
-                    Outcome::Error((Status::BadRequest, Ok(err)))
+                    Outcome::Error((Status::UnprocessableEntity, Ok(err)))
                 }
             },
         }

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -74,7 +74,7 @@ pub fn invalid_short_name() {
 
     let response: LocalResponse = req.dispatch();
 
-    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.status(), Status::UnprocessableEntity);
     assert_eq!(response.content_type(), Some(ContentType::HTML));
 }
 
@@ -89,7 +89,7 @@ pub fn invalid_min_age() {
 
     let response: LocalResponse = req.dispatch();
 
-    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.status(), Status::UnprocessableEntity);
     assert_eq!(response.content_type(), Some(ContentType::HTML));
 }
 
@@ -104,7 +104,7 @@ pub fn invalid_max_age() {
 
     let response: LocalResponse = req.dispatch();
 
-    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.status(), Status::UnprocessableEntity);
     assert_eq!(response.content_type(), Some(ContentType::HTML));
 }
 
@@ -120,6 +120,6 @@ pub fn invalid_request_catcher_response() {
 
     let response: LocalResponse = req.dispatch();
 
-    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.status(), Status::UnprocessableEntity);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 }


### PR DESCRIPTION
`Validated<Json<D>>` will first return deserialized error when the input data doesn't match the data structure, which means some syntax error happened, so all the remained errors throw out by `Validate` should be sematic errors