### PR TITLE
chore: update validator crate to 0.20.0 and add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.idea
 
 
 # Added by cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 rocket = { version = "0.5.0", default-features = false, features = [
     "json",
 ] }
-validator = { version = "0.18.0", features = ["derive"] }
+validator = { version = "0.20.0", features = ["derive"] }
 
 [[example]]
 name = "json-validation"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ extern crate rocket;
 use rocket::{
     data::{Data, FromData, Outcome as DataOutcome},
     form,
+    form::name::NameBuf,
     form::{DataField, FromForm, ValueField},
     http::Status,
     outcome::Outcome,
@@ -277,8 +278,8 @@ impl<'r, T: Validate + FromForm<'r>> FromForm<'r> for Validated<T> {
                     .into_errors()
                     .into_iter()
                     .map(|e| form::Error {
-                        name: Some(e.0.into()),
-                        kind: form::error::ErrorKind::Validation(std::borrow::Cow::Borrowed(e.0)),
+                        name: Some(NameBuf::from(e.0.clone().into_owned())),
+                        kind: form::error::ErrorKind::Validation(e.0),
                         value: None,
                         entity: form::error::Entity::Value,
                     })


### PR DESCRIPTION
## 🚀 Summary

- **Ignore IDE files** by adding `/.idea` to `.gitignore`
- **Upgrade** the `validator` crate from `0.18.0` → `0.20.0` (with `derive` feature)
- **Adjust** Rocket form-validation glue to match Validator 0.20’s API:
  - Import `NameBuf` from `rocket::form::name`
  - Build form errors using an owned `NameBuf` instead of a borrowed `Cow`

---

## 📝 Changes

### 1. `.gitignore`
```diff
 /target
+/.idea
```

- **Prevent IDE-specific files from being committed.**

### 2.  `Cargo.toml`
```diff
[dependencies]
- validator = { version = "0.18.0", features = ["derive"] }
+ validator = { version = "0.20.0", features = ["derive"] }
```

- **Bump to the latest `validator` release for bug fixes and improved derive macros.**
### 3.  `src/lib.rs`
```diff
-use rocket::{
-    data::{Data, FromData, Outcome as DataOutcome},
-    form,
-    form::{DataField, FromForm, ValueField},
-    http::Status,
-    outcome::Outcome,
-};
+use rocket::{
+    data::{Data, FromData, Outcome as DataOutcome},
+    form,
+    form::name::NameBuf,
+    form::{DataField, FromForm, ValueField},
+    http::Status,
+    outcome::Outcome,
+};
```
Form-Validation Impl Update
```diff
 impl<'r, T: Validate + FromForm<'r>> FromForm<'r> for Validated<T> {
     // …
     .map(|e| form::Error {
-        name: Some(e.0.into()),
-        kind: form::error::ErrorKind::Validation(std::borrow::Cow::Borrowed(e.0)),
+        name: Some(NameBuf::from(e.0.clone()).into_owned()),
+        kind: form::error::ErrorKind::Validation(e.0),
         value: None,
         entity: form::error::Entity::Value,
     })
     // …
 }
```
Switch from `Cow::Borrowed(&str)` to fully owned `NameBuf`.

Simplify the `Validation` payload in line with Validator 0.20’s API.
